### PR TITLE
stop sending analytics in debug mode

### DIFF
--- a/Assets/Scripts/AnalyticsSender.cs
+++ b/Assets/Scripts/AnalyticsSender.cs
@@ -5,8 +5,8 @@ using UnityEngine.Analytics;
 
 public class AnalyticsSender 
 {
-    private static readonly string LEVEL_RECAHED = "Level Reached";
-    private static readonly string LEVEL_STARTED = "level started";
+    private static readonly string LEVEL_REACHED = "Level Reached";
+    private static readonly string LEVEL_STARTED = "Level Started";
     private static readonly string TIME_TAKEN_FOR_LEVEL = "Time Taken For Level";
     private static readonly string LEVEL_NUMBER = "Level Number";
     private static readonly string TIME_TAKEN = "Time Taken";
@@ -17,7 +17,8 @@ public class AnalyticsSender
         if(!Debug.isDebugBuild)
         {
             Analytics.CustomEvent(customEventName, eventData);   
-        } else
+        } 
+        else
         {
             string keyValues = "";
             foreach (string k in eventData.Keys)
@@ -33,7 +34,7 @@ public class AnalyticsSender
 
     public static void SendLevelReachedEvent(int levelNumber)
     {
-        AnalyticsSender.CustomEvent(LEVEL_RECAHED, new Dictionary<string, object> { { LEVEL_STARTED, levelNumber } });
+        AnalyticsSender.CustomEvent(LEVEL_REACHED, new Dictionary<string, object> { { LEVEL_STARTED, levelNumber } });
     }
 
     public static void SendLevelFinishedEvent(int levelNumber, int numberOfSeconds) {

--- a/Assets/Scripts/AnalyticsSender.cs
+++ b/Assets/Scripts/AnalyticsSender.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Analytics;
+
+public class AnalyticsSender 
+{
+    public static void CustomEvent(string customEventName, IDictionary<string, object> eventData)
+    {
+        // Only send the data if it is not a Debug build
+        if(!Debug.isDebugBuild)
+        {
+            Analytics.CustomEvent(customEventName, eventData);   
+        } else
+        {
+            string keyValues = "";
+            foreach (string k in eventData.Keys)
+            {
+                keyValues += k + ": " + eventData[k] + "\n";
+            }
+            Debug.Log("Recieved call to send data with event name: " + customEventName + "and with data: \n" + keyValues);
+            
+        }
+    }
+}

--- a/Assets/Scripts/AnalyticsSender.cs
+++ b/Assets/Scripts/AnalyticsSender.cs
@@ -5,7 +5,13 @@ using UnityEngine.Analytics;
 
 public class AnalyticsSender 
 {
-    public static void CustomEvent(string customEventName, IDictionary<string, object> eventData)
+    private static readonly string LEVEL_RECAHED = "Level Reached";
+    private static readonly string LEVEL_STARTED = "level started";
+    private static readonly string TIME_TAKEN_FOR_LEVEL = "Time Taken For Level";
+    private static readonly string LEVEL_NUMBER = "Level Number";
+    private static readonly string TIME_TAKEN = "Time Taken";
+
+    private static void CustomEvent(string customEventName, IDictionary<string, object> eventData)
     {
         // Only send the data if it is not a Debug build
         if(!Debug.isDebugBuild)
@@ -21,5 +27,19 @@ public class AnalyticsSender
             Debug.Log("Recieved call to send data with event name: " + customEventName + "and with data: \n" + keyValues);
             
         }
+    }
+
+
+
+    public static void SendLevelReachedEvent(int levelNumber)
+    {
+        AnalyticsSender.CustomEvent(LEVEL_RECAHED, new Dictionary<string, object> { { LEVEL_STARTED, levelNumber } });
+    }
+
+    public static void SendLevelFinishedEvent(int levelNumber, int numberOfSeconds) {
+        AnalyticsSender.CustomEvent(TIME_TAKEN_FOR_LEVEL, new Dictionary<string, object> {
+            {LEVEL_NUMBER,  levelNumber },
+            {TIME_TAKEN, numberOfSeconds }
+        });
     }
 }

--- a/Assets/Scripts/AnalyticsSender.cs.meta
+++ b/Assets/Scripts/AnalyticsSender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbd0e3758e1f8344a8085da278144110
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Constants.cs
+++ b/Assets/Scripts/Constants.cs
@@ -6,6 +6,7 @@ public static class Constants
 {
     public static Dictionary<string, int> LevelMap { get; set; } = new Dictionary<string, int>
     {
-        {"Poly-Cubes", 1 }
+        {"Yuni-Scene", 1 },
+        {"Poly-Cubes", 2 }
     };
 }

--- a/Assets/Scripts/SolutionManager.cs
+++ b/Assets/Scripts/SolutionManager.cs
@@ -99,7 +99,7 @@ public class SolutionManager : MonoBehaviour
 
         Debug.Log("The current level: " + PlayerData.CurrentLevel);
 
-        AnalyticsSender.CustomEvent("Level Reached", new Dictionary<string, object> { { "level started", PlayerData.CurrentLevel } });
+        AnalyticsSender.SendLevelReachedEvent(PlayerData.CurrentLevel);
         
         foreach (GameObject wallSolution in wallSolutions)
         {

--- a/Assets/Scripts/SolutionManager.cs
+++ b/Assets/Scripts/SolutionManager.cs
@@ -99,7 +99,7 @@ public class SolutionManager : MonoBehaviour
 
         Debug.Log("The current level: " + PlayerData.CurrentLevel);
 
-        Analytics.CustomEvent("Level Reached", new Dictionary<string, object> { { "level started", PlayerData.CurrentLevel } });
+        AnalyticsSender.CustomEvent("Level Reached", new Dictionary<string, object> { { "level started", PlayerData.CurrentLevel } });
         
         foreach (GameObject wallSolution in wallSolutions)
         {

--- a/Assets/Scripts/VictorySceneManager.cs
+++ b/Assets/Scripts/VictorySceneManager.cs
@@ -11,7 +11,7 @@ public class VictorySceneManager : MonoBehaviour
     void Start()
     {
         VictoryText.text += PlayerData.NumberOfSeconds;
-        Analytics.CustomEvent("Time Taken For Level", new Dictionary<string, object> {
+        AnalyticsSender.CustomEvent("Time Taken For Level", new Dictionary<string, object> {
             {"Level Number",  PlayerData.CurrentLevel },
             {"Time Taken", PlayerData.NumberOfSeconds }
         });

--- a/Assets/Scripts/VictorySceneManager.cs
+++ b/Assets/Scripts/VictorySceneManager.cs
@@ -11,10 +11,7 @@ public class VictorySceneManager : MonoBehaviour
     void Start()
     {
         VictoryText.text += PlayerData.NumberOfSeconds;
-        AnalyticsSender.CustomEvent("Time Taken For Level", new Dictionary<string, object> {
-            {"Level Number",  PlayerData.CurrentLevel },
-            {"Time Taken", PlayerData.NumberOfSeconds }
-        });
+        AnalyticsSender.SendLevelFinishedEvent(PlayerData.CurrentLevel, PlayerData.NumberOfSeconds);
     }
 
     // Update is called once per frame


### PR DESCRIPTION
This PR makes the change to only send the analytics when it is a production build. In Debug mode it logs the event to the console. 